### PR TITLE
Ignore default build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ CTestTestfile.cmake
 *.lss
 .idea/*
 cmake-build-debug/*
+/build


### PR DESCRIPTION
The default build directory used by build.bat is "build" so ignore that.