### PR TITLE
Add a CMake target for running OpenOCD and GDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ This will also generate an Intel HEX file (*.hex*), a binary file (*.bin*), a ma
 
 Use `make flash` for flashing via OpenOCD. In this example, the ST-Link on the STM32F4Discovery board is assumed. You might have to adapt this.
 
+## Debugging
+
+The target `ocd_serve` runs OpenOCD against the target and serves an interface for GDB
+to connect to on a local port. This uses the same ST-Link configuration as the `flash` target.
+
+The target `gdb_connect` runs the ARM GDB against this port and provides a live debugger
+for the program running on the device.
+
 # Options
 You may want to use `build-debug` in the early development stage. This will generate Makefiles which compile the firmware with no optimization (**-O0**). Otherwise, optimization for size (**-Os**) will be used.
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,3 +52,19 @@ add_custom_target(${application_name} ALL DEPENDS ${elf_file}-size ${bin_file} $
 add_custom_target(flash DEPENDS ${elf_file} COMMAND ${OPENOCD_EXECUTABLE}
   -f ${OPENOCD_CONFIG}
   --command "program ${elf_file} reset exit")
+
+  # The port that OpenOCD will serve a gdb interface on
+if(NOT GDB_DEBUG_PORT)
+  set(GDB_DEBUG_PORT "4242")
+endif()
+
+# Connect OCD to the device and serve for an incoming GDB connection
+add_custom_target(ocd_serve DEPENDS ${elf_file} COMMAND ${OPENOCD_EXECUTABLE}
+  -f ${OPENOCD_CONFIG}
+  --command "gdb_port ${GDB_DEBUG_PORT}")
+
+# Run GDB against the target on the device, via OpenOCD
+add_custom_target(gdb_connect DEPENDS ${elf_file} COMMAND ${ARM_GDB_EXECUTABLE}
+  -ex "target remote localhost:${GDB_DEBUG_PORT}"
+  -ex "monitor reset halt"
+  ${elf_file})


### PR DESCRIPTION
Provides a simple way for a user to actually put the OCD config and ELF file together in such a way that allows real debugging.